### PR TITLE
parameterize populate.py script and fix pydicom import

### DIFF
--- a/_populate_db/populate.py
+++ b/_populate_db/populate.py
@@ -8,7 +8,7 @@ except ImportError:
 
 assert not os.path.exists(os.path.join(os.path.pardir, 'pylidc.sqlite')), "`pylidc.sqlite` already exists. Aborting."
 
-def getSettings():
+def get_settings():
     # Load the configuration file and get the dicom file path.
     try:
         import configparser
@@ -47,7 +47,7 @@ def getSettings():
     return {"dicom/path":dicompath, "dicom/warn":warndpath, "xml/path":xmlpath}
 
 # Change these. The dicom path should end with `LIDC-IDRI`, and the xml path should end with `tcia-lidc-xml`.
-settings = getSettings()
+settings = get_settings()
 dicom_root_path = settings["dicom/path"]
 # The 161-resubmitted-... file should replace the 161.xml file in this directory. I replace it by overwriting 161.xml while taking the name 161.xml. I'm not sure if this makes a difference.
 xml_root_path = settings["xml/path"]

--- a/_populate_db/populate.py
+++ b/_populate_db/populate.py
@@ -64,11 +64,6 @@ import pylidc as pl
 # This line actually creates the database, `pylidc.db`.
 pl._Base.Base.metadata.create_all(pl._engine)
 
-# Add the dicom path as a configuration, so that the path to
-# dicom files persists across session. This is done so we can write
-# functions for visualizing annotations on top of CT data.
-pl._session.add(pl._Configuration(key='path_to_dicom_files', value=dicom_root_path))
-
 characteristic_names =\
 ['subtlety',
 'internalStructure',


### PR DESCRIPTION
Instead of using hard-coded paths locations, reuse those from settings. While doing that,
added XML annotations location to the configuration. It might make sense to move the getSettings()
function to the util class. It might also be good to add the path to the sqlite database
to the configuration, using the installed one by default.

Fixed `import dicom`, which was removed in pydicom 1.0 - now this is handeled more gracefully
by catching ImportError.