### PR TITLE
Fix matplotlib API change

### DIFF
--- a/pylidc/Annotation.py
+++ b/pylidc/Annotation.py
@@ -842,7 +842,7 @@ class Annotation(Base):
         )
         # Remove the cell borders.
         # It Seems like there should be an easier way to do this...
-        for cell in scan_info_table.properties()['child_artists']:
+        for cell in scan_info_table.properties()['children']:
             cell.set_color('w')
 
         ax_scan_info.set_title('Scan Info')
@@ -873,7 +873,7 @@ class Annotation(Base):
         )
 
         # Again, remove cell borders.
-        for cell in annotation_info_table.properties()['child_artists']:
+        for cell in annotation_info_table.properties()['children']:
             cell.set_color('w')
 
         ax_annotation_info.set_title('Annotation Info')

--- a/pylidc/Scan.py
+++ b/pylidc/Scan.py
@@ -539,7 +539,7 @@ class Scan(Base):
             loc='center', cellLoc='left'
         )
         # Remove the table cell borders.
-        for cell in scan_info_table.properties()['child_artists']:
+        for cell in scan_info_table.properties()['children']:
             cell.set_color('w')
         # Add title, remove ticks from scan info.
         ax_scan_info.set_title('Scan Info')
@@ -561,7 +561,7 @@ class Scan(Base):
             ann_grps_table = ax_ann_grps.table(cellText=txt, loc='center',
                                                cellLoc='left')
             # Remove cell borders.
-            for cell in ann_grps_table.properties()['child_artists']:
+            for cell in ann_grps_table.properties()['children']:
                 cell.set_color('w')
             # Add title, remove ticks from scan info.
             ax_ann_grps.set_title('Nodule Info')


### PR DESCRIPTION
From https://matplotlib.org/api/prev_api_changes/api_changes_3.0.0.html?highlight=child_artists:

> table.Table.get_child_artists (use get_children instead)

`scan.visualize()` should now work with last matplotlib version