### PR TITLE
RescaleIntercept RescaleSlope rescaling of DICOM image

### DIFF
--- a/pylidc/Scan.py
+++ b/pylidc/Scan.py
@@ -637,8 +637,11 @@ class Scan(Base):
         Return the scan as a 3D numpy array volume.
         """
         images = self.load_all_dicom_images(verbose=verbose)
+        rescale_slope = images[0].RescaleSlope
+        rescale_intercept = images[0].RescaleIntercept
 
         volume = np.zeros((512,512,len(images)))
         for i in range(len(images)):
-           volume[:,:,i] = images[i].pixel_array
+            img = images[i].pixel_array * rescale_slope + rescale_intercept
+            volume[:,:,i] = img
         return volume

--- a/pylidc/Scan.py
+++ b/pylidc/Scan.py
@@ -637,11 +637,12 @@ class Scan(Base):
         Return the scan as a 3D numpy array volume.
         """
         images = self.load_all_dicom_images(verbose=verbose)
-        rescale_slope = images[0].RescaleSlope
-        rescale_intercept = images[0].RescaleIntercept
 
-        volume = np.zeros((512,512,len(images)))
-        for i in range(len(images)):
-            img = images[i].pixel_array * rescale_slope + rescale_intercept
-            volume[:,:,i] = img
+        volume = np.stack(
+            [
+                x.pixel_array * x.RescaleSlope + x.RescaleIntercept
+                for x in images
+            ],
+            axis=-1,
+        ).astype(np.int16)
         return volume


### PR DESCRIPTION
current package version doesn't take into account DICOM `(0028, 1052) Rescale Intercept` and `(0028, 1053) Rescale Slope` tags. Which should be used as linear transform coefficients to get pixelarray values in HU range. [(here more info)](http://dicomiseasy.blogspot.com/2012/08/chapter-12-pixel-data.html) 

Erroneous image preprocessing can lead to some unreadable examples.
Note that lowest value here is 0, which is wrong (air in HU has -1000)
![](https://i.imgur.com/hX4S0rn.png)

Note that entire values are far away from real HU distribution
![](https://i.imgur.com/dDSpPuE.png)
