### PR TITLE
Display more dicom metadata in visualization

### DIFF
--- a/pylidc/Annotation.py
+++ b/pylidc/Annotation.py
@@ -830,13 +830,16 @@ class Annotation(Base):
         ax_image.axis('off')
         
         # Add the scan info table
-        ax_scan_info = fig.add_axes([0.1, 0.8, 0.3, 0.1])
+        ax_scan_info = fig.add_axes([0.1, 0.76, 0.3, 0.15])
         ax_scan_info.set_facecolor('w')
         scan_info_table = ax_scan_info.table(
             cellText=[
                 ['Patient ID:', self.scan.patient_id],
                 ['Slice thickness:', '%.3f mm' % self.scan.slice_thickness],
-                ['Pixel spacing:', '%.3f mm'%self.scan.pixel_spacing]
+                ['Pixel spacing:', '%.3f mm'%self.scan.pixel_spacing],
+                ['Manufacturer:', images[current_slice].Manufacturer],
+                ['Model name:', images[current_slice].ManufacturerModelName],
+                ['Convolution kernel:', images[current_slice].ConvolutionKernel],
             ],
             loc='center', cellLoc='left'
         )

--- a/pylidc/Scan.py
+++ b/pylidc/Scan.py
@@ -529,12 +529,15 @@ class Scan(Base):
                 a.set_visible(False) # flipped on/off by `update` function.
                 arrows.append(a)
         
-        ax_scan_info = fig.add_axes([0.1, 0.8, 0.3, 0.1]) # l,b,w,h
+        ax_scan_info = fig.add_axes([0.1, 0.7, 0.3, 0.15]) # l,b,w,h
         ax_scan_info.set_facecolor('w')
         scan_info_table = ax_scan_info.table(cellText=[
                 ['Patient ID:', self.patient_id],
                 ['Slice thickness:', '%.3f mm' % self.slice_thickness],
-                ['Pixel spacing:', '%.3f mm' % self.pixel_spacing]
+                ['Pixel spacing:', '%.3f mm' % self.pixel_spacing],
+                ['Manufacturer:', images[current_slice].Manufacturer],
+                ['Model name:', images[current_slice].ManufacturerModelName],
+                ['Convolution kernel:', images[current_slice].ConvolutionKernel],
             ],
             loc='center', cellLoc='left'
         )


### PR DESCRIPTION
I modified the `scan.visualize()` function to display more data about the scan. Since this modification was useful to me it might be of interest to others.