### PR TITLE
Fix SciPy DeprecationWarning.

### DIFF
--- a/pylidc/Annotation.py
+++ b/pylidc/Annotation.py
@@ -29,7 +29,7 @@ except ImportError:
 from mpl_toolkits.mplot3d import Axes3D
 from mpl_toolkits.mplot3d.art3d import Poly3DCollection
 from scipy.spatial import Delaunay
-from scipy.ndimage.morphology import distance_transform_edt as dtrans
+from scipy.ndimage import distance_transform_edt as dtrans
 
 
 feature_names = \


### PR DESCRIPTION
DeprecationWarning: Please use
`distance_transform_edt` from the `scipy.ndimage`
namespace, the `scipy.ndimage.morphology` namespace is deprecated.

Seen on scipy==1.8.1