### PR TITLE
Fix np.int is deprecated bug

### DIFF
--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.c_[ij, k].astype(np.int)
+            return np.c_[ij, k].astype(np.int_)
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,


### PR DESCRIPTION
# Problem
When I try to run the following code, I meet the numpy deprecated error.
```python
(ai) ➜  ~ ipython
In [1]: import pylidc as pl
In [2]: pl.query(pl.Scan).filter(pl.Scan.patient_id == "LIDC-IDRI-0012").first()
Out[2]: Scan(id=23,patient_id=LIDC-IDRI-0012)
In [3]: scan = pl.query(pl.Scan).filter(pl.Scan.patient_id == "LIDC-IDRI-0012").first()
In [4]: nods = scan.cluster_annotations()
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[4], line 1
----> 1 nods = scan.cluster_annotations()

File ~/anaconda3/envs/ai/lib/python3.10/site-packages/pylidc/Scan.py:439, in Scan.cluster_annotations(self, metric, tol, factor, min_tol, return_distance_matrix, verbose)
    437 for i in range(N):
    438     for j in range(i+1,N):
--> 439         D[i,j] = D[j,i] = metric(self.annotations[i],
    440                                  self.annotations[j])
    442 adjacency = D <= tol
    443 nnods, cids = connected_components(adjacency, directed=False)

File ~/anaconda3/envs/ai/lib/python3.10/site-packages/pylidc/annotation_distance_metrics.py:27, in <lambda>(a, b)
     24     else:
     25         raise ValueError('invalid `which` value.')
---> 27 metrics['min'] = lambda a,b: pairdist(a,b,'min')
     28 metrics['max'] = lambda a,b: pairdist(a,b,'max')
     29 metrics['avg'] = lambda a,b: pairdist(a,b,'avg')

File ~/anaconda3/envs/ai/lib/python3.10/site-packages/pylidc/annotation_distance_metrics.py:15, in pairdist(ann1, ann2, which)
      6 def pairdist(ann1, ann2, which):
      7     """
      8     Compute the pairwise euclidean distance between
      9     the contour boundary points, and return the
   (...)
     13         One of 'min', 'max', or 'avg'.
     14     """
---> 15     dists = cdist(ann1.contours_matrix,
     16                   ann2.contours_matrix)
     18     if   which == 'min':
     19         return dists.min()

File ~/anaconda3/envs/ai/lib/python3.10/site-packages/pylidc/Annotation.py:968, in Annotation.contours_matrix(self)
    963 @property
    964 def contours_matrix(self):
    965     """
    966     All the contour index values a 3D numpy array.
    967     """
--> 968     return np.vstack([c.to_matrix(include_k=True)
    969                             for c in sorted(self.contours,
    970                                     key=lambda c: c.image_z_position)])

File ~/anaconda3/envs/ai/lib/python3.10/site-packages/pylidc/Annotation.py:968, in <listcomp>(.0)
    963 @property
    964 def contours_matrix(self):
    965     """
    966     All the contour index values a 3D numpy array.
    967     """
--> 968     return np.vstack([c.to_matrix(include_k=True)
    969                             for c in sorted(self.contours,
    970                                     key=lambda c: c.image_z_position)])

File ~/anaconda3/envs/ai/lib/python3.10/site-packages/pylidc/Contour.py:111, in Contour.to_matrix(self, include_k)
    109 k  = np.ones(ij.shape[0])*self.image_k_position
    110 zs = self.annotation.contour_slice_zvals
--> 111 return np.c_[ij, k].astype(np.int)

File ~/anaconda3/envs/ai/lib/python3.10/site-packages/numpy/__init__.py:324, in __getattr__(attr)
    319     warnings.warn(
    320         f"In the future `np.{attr}` will be defined as the "
    321         "corresponding NumPy scalar.", FutureWarning, stacklevel=2)
    323 if attr in __former_attrs__:
--> 324     raise AttributeError(__former_attrs__[attr])
    326 if attr == 'testing':
    327     import numpy.testing as testing

AttributeError: module 'numpy' has no attribute 'int'.
`np.int` was a deprecated alias for the builtin `int`. To avoid this error in existing code, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
# Reason
I try to modify the code, `np.int` to `np.int_`, and it works. Then I check the pylidc dependencies [setup.py](https://github.com/notmatthancock/pylidc/blob/8c303c0d4306044983602114de5e9ce5effff137/setup.py#L31) the numpy version is `'numpy>=1.12.0'` , the numpy official [update](https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations) I
So I can make sure, pylidc is compatible with numpy now.

# Summary
`np.int` to `np.int_`