### PR TITLE
Compatibility with Py312 and Numpy2

### DIFF
--- a/pylidc/Annotation.py
+++ b/pylidc/Annotation.py
@@ -641,7 +641,7 @@ class Annotation(Base):
         """
         mask = self.boolean_mask()
         mask = np.pad(mask, [(1,1), (1,1), (1,1)], 'constant') # Cap the ends.
-        mask = mask.astype(np.float)
+        mask = mask.astype(float)
 
         rij  = self.scan.pixel_spacing
         rk   = self.scan.slice_thickness
@@ -752,7 +752,7 @@ class Annotation(Base):
         rk   = self.scan.slice_thickness
 
         if backend == 'matplotlib':
-            verts, faces, _, _= marching_cubes(mask.astype(np.float), 0.5,
+            verts, faces, _, _= marching_cubes(mask.astype(float), 0.5,
                                                spacing=(rij, rij, rk),
                                                step_size=step)
             fig = plt.figure(figsize=figsize)
@@ -781,7 +781,7 @@ class Annotation(Base):
         elif backend == 'mayavi':
             try:
                 from mayavi import mlab
-                sf = mlab.pipeline.scalar_field(mask.astype(np.float))
+                sf = mlab.pipeline.scalar_field(mask.astype(float))
                 sf.spacing = [rij, rij, rk]
                 mlab.pipeline.iso_surface(sf, contours=[0.5])
                 mlab.show()
@@ -1021,7 +1021,7 @@ class Annotation(Base):
 
         # Get dimensions, initialize mask.
         ni,nj,nk = np.diff(bb, axis=1).astype(int)[:,0] + 1
-        mask = np.zeros((ni,nj,nk), dtype=np.bool)
+        mask = np.zeros((ni,nj,nk), dtype=bool)
 
         # We check if these points are enclosed within each contour 
         # for a given slice. `test_points` is a list of image coordinate 
@@ -1052,7 +1052,7 @@ class Annotation(Base):
                 if not include_contour_points:
                     # Remove the contour points themselves.
                     i, j = (C - bb[:2,0]).T
-                    k = np.ones(C.shape[0], dtype=np.int)*zi
+                    k = np.ones(C.shape[0], dtype=int)*zi
                     mask[i,j,k] = False
 
         # Second, we "turn off" pixels enclosed by exclusion contours.
@@ -1072,7 +1072,7 @@ class Annotation(Base):
 
                 # Remove the contour points themselves.
                 i, j = (C - bb[:2,0]).T
-                k = np.ones(C.shape[0], dtype=np.int)*zi
+                k = np.ones(C.shape[0], dtype=int)*zi
                 mask[i,j,k] = False
 
         return mask

--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.c_[ij, k].astype(np.int)
+            return np.c_[ij, k].astype(int)
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,

--- a/pylidc/Scan.py
+++ b/pylidc/Scan.py
@@ -6,25 +6,25 @@ import pydicom as dicom
 import numpy as np
 
 import sqlalchemy as sq
-from sqlalchemy.orm import relationship
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
 from ._Base import Base
 
 import matplotlib.pyplot as plt
-from matplotlib.widgets import Slider, CheckButtons
+from matplotlib.widgets import Slider
 
-from scipy.spatial.distance import cdist
 from scipy.sparse.csgraph import connected_components
 from .annotation_distance_metrics import metrics
 
-from scipy.stats import mode
 
 try:
     import configparser
 except ImportError:
     import ConfigParser
     configparser = ConfigParser
+# in Py>=3.12 SafeConfigParser was removed
+if hasattr(configparser, 'SafeConfigParser'):
+    SafeConfigParser = configparser.SafeConfigParser
+else:
+    SafeConfigParser = configparser.ConfigParser
 
 
 def _get_config_filename():
@@ -52,11 +52,11 @@ def _get_dicom_file_path_from_config_file():
     """
     conf_file = _get_config_file()
 
-    parser = configparser.SafeConfigParser()
+    parser = SafeConfigParser()
 
     if os.path.exists(conf_file):
         parser.read(conf_file)
-        
+
     try:
         return parser.get(section='dicom', option='path')
     except (configparser.NoSectionError,
@@ -176,7 +176,7 @@ class Scan(Base):
             raise ValueError(msg)
         else:
             super(Scan, self).__setattr__(name,value)
-    
+
     def get_path_to_dicom_files(self):
         """
         Get the path to where the DICOM files are stored for this scan, 
@@ -230,7 +230,7 @@ class Scan(Base):
             for dpath,dnames,fnames in os.walk(base):
                 # Skip if no files in current dir.
                 if len(fnames) == 0: continue
-                
+
                 # Gather up DICOM files in dir (if any).
                 dicom_file = [d for d in fnames if d.endswith(".dcm") and not d.startswith(".")]
 
@@ -464,7 +464,7 @@ class Scan(Base):
 
         # Sort the clusters by increasing average z value of centroids.
         # This is really a convienience thing for the `scan.visualize` method.
-        clusters = sorted(clusters, 
+        clusters = sorted(clusters,
                           key=lambda cluster: np.mean([ann.centroid[2]
                                                        for ann in cluster]))
 
@@ -528,7 +528,7 @@ class Scan(Base):
                                                       edgecolor='r'))
                 a.set_visible(False) # flipped on/off by `update` function.
                 arrows.append(a)
-        
+
         ax_scan_info = fig.add_axes([0.1, 0.7, 0.3, 0.15]) # l,b,w,h
         ax_scan_info.set_facecolor('w')
         scan_info_table = ax_scan_info.table(cellText=[
@@ -553,7 +553,7 @@ class Scan(Base):
         if annotation_groups is not None and nnods != 0:
             # The values here were chosen heuristically.
             ax_ann_grps = fig.add_axes([0.1, 0.45-nnods*0.01,
-                                        0.3, 0.2+0.01*nnods]) 
+                                        0.3, 0.2+0.01*nnods])
             txt = [['Num Nodules:', str(nnods)]]
             for i in range(nnods):
                 c = centroids[i]

--- a/pylidc/utils.py
+++ b/pylidc/utils.py
@@ -141,7 +141,7 @@ def volume_viewer(vol, mask=None, axis=2, aspect=None, **line_kwargs):
         contours = []
         for i in range(nslices):
             contour = []
-            for c in find_contours(mask[slc(i)].astype(np.float), 0.5):
+            for c in find_contours(mask[slc(i)].astype(float), 0.5):
                 line = aximg.plot(c[:,1], c[:,0], **line_kwargs)[0]
                 line.set_visible(0)
                 contour.append(line)


### PR DESCRIPTION
Hi! 
Here are just a couple of fixes that add compatibility with Python>=3.12 and numpy>=2.0.0. 
I replaced access to some removed attributes (e.g. np.float) and patched SafeConfigParser.