### PR TITLE
Addressing Numpy 1.20 deprecation error 

### DIFF
--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.c_[ij, k].astype(int)
+            return np.c_[ij, k]
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,

--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.int32(np.c_[ij, k])
+            return np.c_[ij, k]
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,

--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.c_[ij, k]
+            return np.int32(np.c_[ij, k])
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,


### PR DESCRIPTION
Addressing issue #70 by removing the .astype(int) deprecated call, as the ij array is already an int64 np array