### PR TITLE
Addressing the Numpy 1.20 deprecation error 

### DIFF
--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.c_[ij, k].astype(int)
+            return np.c_[ij, k]
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,

--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.int32(np.c_[ij, k])
+            return np.c_[ij, k]
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,

--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.c_[ij, k]
+            return np.int32(np.c_[ij, k])
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,

--- a/pylidc/Contour.py
+++ b/pylidc/Contour.py
@@ -108,7 +108,7 @@ class Contour(Base):
         else:
             k  = np.ones(ij.shape[0])*self.image_k_position
             zs = self.annotation.contour_slice_zvals
-            return np.c_[ij, k]
+            return np.c_[ij, k].astype(np.int64)
     
 Annotation.contours = relationship('Contour',
                                    order_by=Contour.id,


### PR DESCRIPTION
Casting the output of the `to_matrix ` function from Contour.py to `np.int64` rather than python native ` int`